### PR TITLE
Add should matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dynamoid-paperclip.gemspec
-gem 'dynamoid'
-gem 'paperclip', '~> 5.0'
-
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dynamoid-paperclip.gemspec
 gem 'dynamoid'
-gem 'paperclip', '~> 3.0'
+gem 'paperclip', '~> 5.0'
 

--- a/dynamoid-paperclip.gemspec
+++ b/dynamoid-paperclip.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency 'dynamoid'
-  spec.add_dependency 'paperclip', '~> 5.0'
+  spec.add_dependency 'paperclip', '~> 6.1'
 end

--- a/dynamoid-paperclip.gemspec
+++ b/dynamoid-paperclip.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency 'dynamoid'
-  spec.add_dependency 'paperclip', '~> 3.0'
+  spec.add_dependency 'paperclip', '~> 5.0'
 end

--- a/lib/dynamoid/paperclip/matchers.rb
+++ b/lib/dynamoid/paperclip/matchers.rb
@@ -1,0 +1,50 @@
+require 'dynamoid/paperclip/matchers/have_dynamoid_attached_file_matcher'
+
+module Dynamoid
+  module Paperclip
+    module Shoulda
+      # Provides RSpec-compatible & Test::Unit-compatible matchers for testing Dynamoid::Paperclip attachments.
+      #
+      # *RSpec*
+      #
+      # In spec_helper.rb, you'll need to require the matchers:
+      #
+      #   require "dynamoid/paperclip/matchers"
+      #
+      # And _include_ the module:
+      #
+      #   RSpec.configure do |config|
+      #     config.include Dynamoid::Paperclip::Shoulda::Matchers
+      #   end
+      #
+      # Example:
+      #   describe User do
+      #     it { should have_dynamoid_attached_file(:avatar) }
+      #   end
+      #
+      # *TestUnit*
+      #
+      # In test_helper.rb, you'll need to require the matchers as well:
+      #
+      #   require "dynamoid/paperclip/matchers"
+      #
+      # And _extend_ the module:
+      #
+      #   class ActiveSupport::TestCase
+      #     extend Dynamoid::Paperclip::Shoulda::Matchers
+      #
+      #     #...other initializers...#
+      #   end
+      #
+      # Example:
+      #   require 'test_helper'
+      #
+      #   class UserTest < ActiveSupport::TestCase
+      #     should have_dynamoid_attached_file(:avatar)
+      #   end
+      #
+      module Matchers
+      end
+    end
+  end
+end

--- a/lib/dynamoid/paperclip/matchers/have_dynamoid_attached_file_matcher.rb
+++ b/lib/dynamoid/paperclip/matchers/have_dynamoid_attached_file_matcher.rb
@@ -1,0 +1,18 @@
+module Dynamoid
+  module Paperclip
+    module Shoulda
+      module Matchers
+        def have_dynamoid_attached_file(name)
+          HaveDynamoidAttachedFileMatcher.new(name)
+        end
+
+        class HaveDynamoidAttachedFileMatcher < ::Paperclip::Shoulda::Matchers::HaveAttachedFileMatcher
+          def has_column?
+            column_names = @subject.attributes.keys.map(&:to_s)
+            column_names.include?("#{@attachment_name}_file_name")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/paperclip/version.rb
+++ b/lib/dynamoid/paperclip/version.rb
@@ -1,5 +1,5 @@
 module Dynamoid
   module Paperclip
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
This gem dose not seem to be maintained for a long time.
So I found repository which bumped paperclip and added shoulda-matcher.
I create this pull request because I'd like to maintain in the original repository.
What do you think about it?

I'm using this gem following environment.

* Ruby (2.5.0)
* Rails (5.1.4)
* dynamoid (2.0.0)
* paperclip (5.1.0)

